### PR TITLE
Invoke ginkgo with default args from task

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-ginkgo.exe -p -r --race -keep-going --randomize-suites --fail-on-pending
+Invoke-Expression "go run github.com/onsi/ginkgo/v2/ginkgo $args"
 if ($LastExitCode -ne 0) {
   throw "tests failed"
 }


### PR DESCRIPTION
Additionally, use go moduled ginkgo instead of the one on PATH, so that it will always remain up-to-date