### PR TITLE
Fix cert bundle directory name

### DIFF
--- a/injector/injector.go
+++ b/injector/injector.go
@@ -48,7 +48,7 @@ func (i Injector) InjectCert(grootDriverStore, uri, certDirectory string) error 
 		return fmt.Errorf("hydrate remove-layer -ociImage %s failed: %s\n", uri, err)
 	}
 
-	containerId := fmt.Sprintf("layer-%d", int32(time.Now().Unix()))
+	containerId := fmt.Sprintf("layer-%d", int32(time.Now().UnixNano()))
 
 	grootOutput, stderr, err := i.cmd.Run(grootBin, "--driver-store", grootDriverStore, "create", uri, containerId)
 	if err != nil {
@@ -65,7 +65,8 @@ func (i Injector) InjectCert(grootDriverStore, uri, certDirectory string) error 
 		}
 	}()
 
-	bundleDir, err := os.MkdirTemp("", containerId)
+	bundleDir := filepath.Join(os.TempDir(), containerId)
+	err = os.MkdirAll(bundleDir, 0755)
 	if err != nil {
 		return fmt.Errorf("create bundle directory failed: %s", err)
 	}

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -3,6 +3,8 @@ package injector_test
 import (
 	"errors"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"code.cloudfoundry.org/cert-injector/fakes"
 	"code.cloudfoundry.org/cert-injector/injector"
@@ -74,6 +76,9 @@ var _ = Describe("cert-injector", func() {
 		By("calling winc to create a container")
 		Expect(fakeCmd.RunCall.Receives[2].Executable).To(ContainSubstring("winc.exe"))
 		Expect(fakeCmd.RunCall.Receives[2].Args).To(ConsistOf("run", "-b", ContainSubstring("layer"), ContainSubstring("layer")))
+
+		By("creating a bundle directory using the name of the containerId passed to winc")
+		Expect(fakeCmd.RunCall.Receives[2].Args[2]).To(Equal(filepath.Join(os.TempDir(), fakeCmd.RunCall.Receives[2].Args[3])))
 
 		By("calling diff-exporter to export the top layer")
 		Expect(fakeCmd.RunCall.Receives[3].Executable).To(ContainSubstring("diff-exporter.exe"))


### PR DESCRIPTION
winc relies on the bundle directory name being the same as the container ID. When switching to os.MkdirTemp, this added extra uniqueness to the bundle directories that was not reflected in the container IDs.

This reverts this behavior while retaining the changes that resolved flakey failures.